### PR TITLE
Update stefanzweifel/git-auto-commit-action

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -31,6 +31,7 @@ jobs:
         run: npm run build
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        # v6.0.1
+        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0
         with:
           commit_message: 'Chore: build assets'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
         uses: aglipanci/laravel-pint-action@2.5
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        # v6.0.1
+        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0
         with:
           commit_message: 'Chore: Fix PHP code styling'


### PR DESCRIPTION
Updates `stefanzweifel/git-auto-commit-action` Github action and changes to referencing the action via git hashes instead of tags, which are vulnerable to exploit.